### PR TITLE
Add HTTP status code as `code` to error object

### DIFF
--- a/js/qbProxy.js
+++ b/js/qbProxy.js
@@ -69,7 +69,7 @@ ServiceProxy.prototype.ajax = function(params, callback) {
     },
     error: function(jqHXR, status, error) {
       if (config.debug) {console.debug('ServiceProxy.ajax error', jqHXR, status, error);}
-      var errorMsg = {status: status, message:error};
+      var errorMsg = {code: jqHXR.status, status: status, message:error};
       if (jqHXR && jqHXR.responseText){ errorMsg.detail = jqHXR.responseText || jqHXR.responseXML; }
       if (config.debug) {console.debug("ServiceProxy.ajax error", error);}
       callback(errorMsg, null);


### PR DESCRIPTION
It's not very good to rely on `error.message`, which is string like `Not Found`, to handle specific errors, so it would be really nice to have an access to the actual HTTP status code. 

That also means the documentation for `REST API` should be improved by adding information about available HTTP status codes for each API call and their meanings. For instance I expected `http://api.quickblox.com/geodata/find.json` to return an empty array even if nothing has been found, but in reality it responds with `404 Not Found`.
