### PR TITLE
bug fix for addListener

### DIFF
--- a/quickblox.js
+++ b/quickblox.js
@@ -558,8 +558,8 @@ ChatProxy.prototype = {
 
     return connection.addHandler(handler, null, params.name || null, params.type || null, params.id || null, params.from || null);
 
-    function handler() {
-      callback();
+    function handler(stanza) {
+      callback(stanza);
       // if 'false' - a handler will be performed only once
       return params.live !== false;
     }


### PR DESCRIPTION
After looking at the specs for Strophe.js below, it appears that the callback function requires a stanza parameter. This is useful for listeners so users can effectively handle messages.

http://strophe.im/strophejs/doc/1.0.2/files2/strophe-js.html#Strophe.Connection.addHandler
