### PR TITLE
Add version and build version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,29 @@ gulp.task('connect', function() {
     });
 });
 
+gulp.task('generate-build_version', function() {
+    var fs = require('fs');
+    const configPath = './src/qbConfig.js';
+
+    function incBuildVersion(buildVersion) {
+        return --buildVersion;
+    }
+
+    fs.readFile(configPath, 'utf8', function (error, config) {
+        if (error) {
+            throw new Error(error);
+        }
+    
+        var result = config.replace(/-\d{4}/g, incBuildVersion);
+
+        fs.writeFile(configPath, result, 'utf8', function (error) {
+            if (error) {
+                throw new Error(error);
+            }
+        });
+    });
+});
+
 gulp.task('watch', function () {
   gulp.watch(['./src/**/*.js'], ['build']);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,16 +37,17 @@ gulp.task('generate-build_version', function() {
     var fs = require('fs');
     const configPath = './src/qbConfig.js';
 
-    function incBuildVersion(buildVersion) {
-        return --buildVersion;
+    function incBuildNumber(foundedString, p1, buildNumber, p2) {
+        var oldBuildNumber = +buildNumber;
+
+        return p1 + (oldBuildNumber + 1) + p2;
     }
 
     fs.readFile(configPath, 'utf8', function (error, config) {
         if (error) {
             throw new Error(error);
         }
-    
-        var result = config.replace(/-\d{4}/g, incBuildVersion);
+        var result = config.replace(/(buildNumber:\s\')(\d{4})(')/g, incBuildNumber);
 
         fs.writeFile(configPath, result, 'utf8', function (error) {
             if (error) {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "scripts": {
     "setDependencies": "npm i && npm install -g gulp-cli && npm install -g jasmine",
     "lint": "jshint src --reporter=node_modules/jshint-stylish",
-    "build": "npm run lint && gulp build",
+    "build": "npm run lint && gulp generate-build_version && gulp build",
     "develop": "cross-env NODE_ENV=develop gulp",
     "start": "gulp connect"
   }

--- a/samples/chat/css/style.css
+++ b/samples/chat/css/style.css
@@ -33,6 +33,14 @@
 
 p {display: block;}
 
+.ver {
+  position: relative;
+  display: block;
+  padding: 20px;
+  line-height: 20px;
+  color: #333;
+}
+
 .panel {
   -webkit-box-shadow: none;
   box-shadow:none;

--- a/samples/chat/index.html
+++ b/samples/chat/index.html
@@ -34,6 +34,9 @@
                     <li>
                         <a href="#" onclick="showDialogInfoPopup()">Dialog info</a>
                     </li>
+                    <li>
+                        <span class="j-version ver"></span>
+                    </li>
                 </ul>
 
                 <a href="https://github.com/QuickBlox/quickblox-javascript-sdk/tree/gh-pages/samples/chat"

--- a/samples/chat/js/config.js
+++ b/samples/chat/js/config.js
@@ -43,3 +43,5 @@ var QBUser1 = {
     };
 
 QB.init(QBApp.appId, QBApp.authKey, QBApp.authSecret, config);
+
+$('.j-version').text('v.' + QB.version + QB.versionBuild);

--- a/samples/chat/js/config.js
+++ b/samples/chat/js/config.js
@@ -44,4 +44,4 @@ var QBUser1 = {
 
 QB.init(QBApp.appId, QBApp.authKey, QBApp.authSecret, config);
 
-$('.j-version').text('v.' + QB.version + QB.versionBuild);
+$('.j-version').text('v.' + QB.version + '.' + QB.buildNumber);

--- a/samples/webrtc/config.js
+++ b/samples/webrtc/config.js
@@ -1,4 +1,6 @@
 ;(function(window) {
+    'use strict';
+
     var CONFIG = {
         debug: true,
         webrtc: {

--- a/samples/webrtc/index.html
+++ b/samples/webrtc/index.html
@@ -24,6 +24,7 @@
                 </div>
 
                 <h2 class="header__title">JavaScript WebRTC Sample</h2>
+                <span class="j-version header_version"></span>
             </div>
         </header>
 

--- a/samples/webrtc/js/app.js
+++ b/samples/webrtc/js/app.js
@@ -201,7 +201,7 @@
         );
 
         /* Insert version + versiobBuild to sample for QA */
-        $('.j-version').text('v.' + QB.version + QB.versionBuild);
+        $('.j-version').text('v.' + QB.version + '.' + QB.buildNumber);
 
         var statesPeerConn = _.invert(QB.webrtc.PeerConnectionState);
 

--- a/samples/webrtc/js/app.js
+++ b/samples/webrtc/js/app.js
@@ -200,6 +200,9 @@
             CONFIG.APP_CONFIG
         );
 
+        /* Insert version + versiobBuild to sample for QA */
+        $('.j-version').text('v.' + QB.version + QB.versionBuild);
+
         var statesPeerConn = _.invert(QB.webrtc.PeerConnectionState);
 
         app.router = new Router();

--- a/samples/webrtc/styles.css
+++ b/samples/webrtc/styles.css
@@ -107,6 +107,7 @@ b {
     }
 
 .inner {
+    position: relative;
     width: 90%;
     max-width: 890px;
     margin: 0 auto;
@@ -150,6 +151,7 @@ b {
 }
 
 .header__title {
+    position: relative;
     font-size: 26px;
     font-weight: 300;
     line-height: 35px;
@@ -158,6 +160,12 @@ b {
     .header__logo,
     .header__title {
         text-align: center;
+    }
+
+    .header_version {
+        position: absolute;
+        bottom: 100%;
+        right: 0;
     }
 
 @media all and (min-width: 780px) {

--- a/src/qbConfig.js
+++ b/src/qbConfig.js
@@ -13,7 +13,7 @@
 
 var config = {
   version: '2.4.0',
-  buildNumber: '1001',
+  buildNumber: '1002',
   creds: {
     appId: '',
     authKey: '',

--- a/src/qbConfig.js
+++ b/src/qbConfig.js
@@ -13,7 +13,7 @@
 
 var config = {
   version: '2.4.0',
-  versionBuild: '-1002',
+  buildNumber: '1001',
   creds: {
     appId: '',
     authKey: '',

--- a/src/qbConfig.js
+++ b/src/qbConfig.js
@@ -13,6 +13,7 @@
 
 var config = {
   version: '2.4.0',
+  versionBuild: '-1002',
   creds: {
     appId: '',
     authKey: '',

--- a/src/qbMain.js
+++ b/src/qbMain.js
@@ -22,7 +22,7 @@ QuickBlox.prototype = {
     }
 
     this.version = config.version;
-    this.versionBuild = config.versionBuild;
+    this.buildNumber = config.buildNumber;
 
     var Proxy = require('./qbProxy');
     this.service = new Proxy();

--- a/src/qbMain.js
+++ b/src/qbMain.js
@@ -21,6 +21,9 @@ QuickBlox.prototype = {
       config.set(configMap);
     }
 
+    this.version = config.version;
+    this.versionBuild = config.versionBuild;
+
     var Proxy = require('./qbProxy');
     this.service = new Proxy();
 


### PR DESCRIPTION
**Made/Proposed changes:**
 - Make the property `QB.version` public; 
 - Added the property `QB.versionBuild`, also as public;
 - Added the `gulp generate-build_version` task and added in `npm run build`;
 - Show in samples (chat, webrtc) v.{version}{-versionBuild};

WHY uses '-xxxx' as build version?
It's a common practice in semver.

**How should this be manually tested?**
For generating a new build version run `npm run build`;
Check new build version in a sample (chat or webrtc)

**Does the documentation need an update?**
No 